### PR TITLE
fix: update silly-app image to nginx:latest to resolve deployment drift

### DIFF
--- a/production/manifests/silly-app/application.yaml
+++ b/production/manifests/silly-app/application.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: silly-app
-        image: nginx:missing
+        image: nginx:latest
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR updates the silly-app deployment image from `nginx:missing` to `nginx:latest` to resolve the deployment drift and allow the app to become healthy in the cluster.