### PR TITLE
fix: use valid nginx:latest image for silly-app deployment

### DIFF
--- a/production/manifests/silly-app/application.yaml
+++ b/production/manifests/silly-app/application.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: silly-app
-        image: nginx:missing
+        image: nginx:latest
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR updates the silly-app deployment to use the valid nginx:latest image instead of the invalid nginx:missing. This will resolve the stuck Progressing state in ArgoCD and allow the deployment to become healthy.